### PR TITLE
Use https in submodule to allow pip install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hca2wav"]
 	path = hca2wav
-	url = https://github.com:Cryptomelone/hca2wav.git
+	url = https://github.com/Cryptomelone/hca2wav.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "hca2wav"]
 	path = hca2wav
-	url = git@github.com:Cryptomelone/hca2wav.git
+	url = https://github.com:Cryptomelone/hca2wav.git


### PR DESCRIPTION
Change the protocol from SSH to https so that user can pip install.
Previously submodule will be cloned using SSH, which requires setting up SSH key.